### PR TITLE
Feature/agent mt

### DIFF
--- a/scriptUtil/Agent_Multi-Thread/_command_list_apiborne/Debug-off.bat
+++ b/scriptUtil/Agent_Multi-Thread/_command_list_apiborne/Debug-off.bat
@@ -1,23 +1,32 @@
 @echo off
 echo [INFO] --- DEBUG OFF : Désactive le remote debugging et retire le flag ---
 
-REM 1. Trouver l'IP VPN (même logique que debug-on)
-FOR /F "tokens=2 delims=:" %%A IN ('ipconfig ^| findstr /R /C:"IPv4.*10\.10\."') DO (
-    SET IP_VPN=%%A
-)
-IF "%IP_VPN%"=="" (
-    echo [INFO] Aucune IP 10.10.x.x détectée, suppression forcée.
-) ELSE (
-    SET IP_VPN=%IP_VPN: =%
-    REM 2. Supprimer la redirection netsh
-    netsh interface portproxy delete v4tov4 listenaddress=%IP_VPN% listenport=9222
-)
+REM Liste les redirection active
+C:\Windows\System32\netsh interface portproxy show all
 
-::REM 3. Supprimer la règle firewall
-::netsh advfirewall firewall delete rule name="RemoteDebug9222"
+::REM 1. Trouver l'IP VPN (même logique que debug-on)
+::FOR /F "tokens=2 delims=:" %%A IN ('ipconfig ^| findstr /R /C:"IPv4.*10\.10\."') DO (
+::    SET IP_VPN=%%A
+::)
+::IF "%IP_VPN%"=="" (
+::    echo [INFO] Aucune IP 10.10.x.x détectée, suppression forcée.
+::) ELSE (
+::    SET IP_VPN=%IP_VPN: =%
+::    REM 2. Supprimer la redirection netsh
+::    C:\Windows\System32\netsh interface portproxy delete v4tov4 listenaddress=%IP_VPN% listenport=9123
+::)
 
-REM 4. Supprimer le fichier de flag
-if exist "C:\mode-debug-actif" del "C:\mode-debug-actif"
+echo "[INFO] --- Libere tous les proxy lances
+C:\Windows\System32\netsh interface portproxy reset
+
+C:\Windows\System32\netsh interface portproxy show all
+
+REM Liste les ports en ecoute
+echo "[INFO] --- Libere tous les ports en ecoute
+C:\Windows\System32\netstat -an | findstr "LISTENING"
+
+REM Supprimer le fichier de flag
+if exist "C:\kioskreactor\temp\mode-debug-actif" del "C:\kioskreactor\temp\mode-debug-actif"
 
 echo [OK] Remote debugging désactivé et fichier flag supprimé.
 

--- a/scriptUtil/Agent_Multi-Thread/_command_list_apiborne/Debug-on.bat
+++ b/scriptUtil/Agent_Multi-Thread/_command_list_apiborne/Debug-on.bat
@@ -1,7 +1,7 @@
 @echo off
 echo [INFO] --- DEBUG ON : Active le remote debugging et le signale par un fichier ---
 
-REM 1. Trouver l'IP VPN de la borne (adapté pour un VPN en 10.10.2.x)
+REM 1. Trouver l'IP VPN de la borne (adapté pour un VPN en 10.10.x.x)
 FOR /F "tokens=2 delims=:" %%A IN ('ipconfig ^| findstr /R /C:"IPv4.*10\.10\."') DO (
     SET IP_VPN=%%A
 )
@@ -12,12 +12,14 @@ IF "%IP_VPN%"=="" (
 SET IP_VPN=%IP_VPN: =%
 
 REM 2. Configurer netsh portproxy
-netsh interface portproxy add v4tov4 listenaddress=%IP_VPN% listenport=9222 connectaddress=127.0.0.1 connectport=9222
+echo "[INFO] Creation du proxy : %IP_VPN%:9123 -> 127.0.0.1:9222"
+C:\Windows\System32\netsh interface portproxy add v4tov4 listenaddress=%IP_VPN% listenport=9123 connectaddress=127.0.0.1 connectport=9222
+C:\Windows\System32\netsh interface portproxy show all
 
-::REM 3. Ouvrir le firewall pour tout le subnet 10.10.0.0/16
-::netsh advfirewall firewall add rule name="RemoteDebug9222" dir=in action=allow protocol=TCP localport=9222 remoteip=10.10.0.0/16
 
-REM 4. Créer le fichier de flag
-echo Debug actif > "C:\mode-debug-actif"
 
-echo [OK] Remote debugging actif sur %IP_VPN%:9222 et fichier flag créé.
+REM Créer le fichier de flag
+if not exist "C:\kioskreactor\temp" mkdir C:\kioskreactor\temp
+echo Debug actif > "C:\kioskreactor\temp\mode-debug-actif"
+
+echo [OK] Remote debugging actif, fichier flag créé.

--- a/scriptUtil/Agent_Multi-Thread/_command_list_apiborne/Stream.bat
+++ b/scriptUtil/Agent_Multi-Thread/_command_list_apiborne/Stream.bat
@@ -4,5 +4,4 @@ echo "Test du streaming"
 
 ipconfig
 
-ping 10.10.10.1
-
+ping -n 10 10.10.10.1

--- a/scriptUtil/Agent_Multi-Thread/configuration.json
+++ b/scriptUtil/Agent_Multi-Thread/configuration.json
@@ -6,31 +6,18 @@
     "config": {
         "vars_files": [
             "c:\\kioskReactor\\conf\\device.json",
-			"C:\\tools\\SafiKioskExe\\config.ini"
+            "c:\\tools\\SafiKioskExe\\config.ini"
         ],
         "web": {
             "port": 4000,
             "web": [
-                {
-                    "/cmd": "{COMMAND}",
-                    "type": "cmd"
-                },
-                {
-                    "/conf": "{CONF}",
-                    "type": "html"
-                },
-                {
-                    "/conf/json": "{CONF}",
-                    "type": "json"
-                },
-                {
-                    "/conf/md": "{CONF}",
-                    "type": "markdown"
-                },
-				{
-					"/proxy-ip":   "http://10.10.10.1/ip.php",
-					"type": "proxy"
-				}
+                { "/cmd": "{COMMAND}", "type": "cmd" },
+                { "/conf": "{CONF}",   "type": "html" },
+                { "/conf/json": "{CONF}", "type": "json" },
+                { "/conf/md": "{CONF}", "type": "markdown" },
+				{ "/logs/kiosk": "c:\\kioskReactor\\logs\\", "type": "file"},
+				{ "/logs/safi": "c:\\tools\\SafiKioskExe\\logs\\", "type": "file"},
+                { "/proxy-ip": "http://10.10.10.1/ip.php", "type": "proxy" }
             ],
             "whitelist": [
                 "127.0.0.1",
@@ -40,7 +27,7 @@
         },
         "mqtt": {
             "server": "vpn.apiborne.com",
-            "port": 5883,
+            "port": [ 5883, 80 ],
             "ssl": true,
             "topic_cmd": [
                 "apiborne/{name}/cmd"
@@ -55,8 +42,8 @@
                 "Update",
                 "Vpn-on",
                 "Vpn-off",
-				"Debug-on",
-				"Debug-off",
+                "Debug-on",
+                "Debug-off",
 				"Stream"
             ],
             "mqtt_topic_response": "apiborne/{name}/cmd_response"
@@ -73,18 +60,14 @@
                 "usb": "usb_info"
             },
             "urls": {
-                "apiborne": "http://crt.apiborne.com/keep-alive.php?name={name}"
+				"apiborne": "http://10.10.10.1/keep-alive.php?name={name}"
             },
-			"ping": {
-				"im30": "{im30_ip}"
-			},
+            "ping": {
+                "im30": "{im30_ip}"
+            },
             "sortie": {
                 "fichier": [
-                    {
-                        "actif": "y",
-                        "chemin": "sysinfo_{name}.html",
-                        "mode": "html"
-                    }
+                    { "actif": "y", "chemin": ".\\logs\\sysinfo_{name}.html", "mode": "html" }
                 ],
                 "mqtt": {
                     "actif": "y",
@@ -93,22 +76,10 @@
                     ]
                 },
                 "web": [
-                    {
-                        "/keep-alive": "{JSON}",
-                        "type": "html"
-                    },
-                    {
-                        "/keep-alive/json": "{JSON}",
-                        "type": "json"
-                    },
-                    {
-                        "/keep-alive/md": "{JSON}",
-                        "type": "markdown"
-                    },
-                    {
-                        "/keep-alive/html": "sysinfo_{name}.html",
-                        "type": "file"
-                    }
+                    { "/keep-alive": "{JSON}", "type": "html" },
+                    { "/keep-alive/json": "{JSON}", "type": "json" },
+                    { "/keep-alive/md": "{JSON}", "type": "markdown" },
+                    { "/keep-alive/html": ".\\logs\\sysinfo_{name}.html", "type": "file" }
                 ]
             }
         },
@@ -120,21 +91,17 @@
                 "mem_chrome": "mem_usage:chrome"
             },
             "ping": {
-				"im30": "{im30_ip}",
+                "im30": "{im30_ip}",
                 "openvpn": "10.10.10.1",
                 "google": "8.8.8.8"
             },
             "urls": {
                 "easydoct": "https://www.easydoct.com/Images/easydoct.png",
-                "apiborne": "http://crt.apiborne.com/ip.php"
+                "apiborne": "http://10.10.10.1/keep-alive.php?name={name}"
             },
             "sortie": {
                 "fichier": [
-                    {
-                        "actif": "y",
-                        "chemin": "debug_{name}_{year}{month}{day}.log",
-                        "mode": "log"
-                    }
+                    { "actif": "y", "chemin": ".\\logs\\{year}\\{month}\\{day}\\debug_{name}.log", "mode": "log" }
                 ],
                 "mqtt": {
                     "actif": "y",
@@ -143,26 +110,11 @@
                     ]
                 },
                 "web": [
-                    {
-                        "/debug": "{JSON}",
-                        "type": "html"
-                    },
-                    {
-                        "/debug/json": "{JSON}",
-                        "type": "json"
-                    },
-                    {
-                        "/debug/md": "{JSON}",
-                        "type": "markdown"
-                    },
-                    {
-                        "/debug/html": "debug_{name}_{year}{month}{day}.log",
-                        "type": "file"
-                    },
-                    {
-                        "/debug/vega": "debug_{name}_{year}{month}{day}.log",
-                        "type": "vega"
-                    }
+                    { "/debug": "{JSON}", "type": "html" },
+                    { "/debug/json": "{JSON}", "type": "json" },
+                    { "/debug/md": "{JSON}", "type": "markdown" },
+                    { "/debug/vega": ".\\logs\\{year}\\{month}\\{day}\\debug_{name}.log", "type": "vega" },
+					{ "/logs/agent": ".\\logs\\", "type": "file"}
                 ]
             }
         }

--- a/scriptUtil/chrome/chromeKioskRemoteDebugger.bat
+++ b/scriptUtil/chrome/chromeKioskRemoteDebugger.bat
@@ -24,8 +24,9 @@ if not exist "%CHROME_PATH%" (
     exit /b 2
 )
 
-
-netsh interface portproxy delete v4tov4 listenport=9222 listenaddress=0.0.0.0
+:: Libere tous les proxy pour être sur qu'aucun ne va bloquer le demarrage de chrome
+c:\windows\system32\netsh interface portproxy reset
+:: netsh interface portproxy delete v4tov4 listenport=9222 listenaddress=0.0.0.0
 
 cls
 :: Lancer Chrome en mode debug
@@ -46,27 +47,33 @@ start "" "%CHROME_PATH%" ^
  --overscroll-history-navigation=0 ^
  --disable-infobars ^
  --remote-debugging-port=%REMOTE_PORT% ^
+ --remote-debugging-address=127.0.0.1 ^
  --user-data-dir="%USER_DATA_DIR%" ^
  --allow-file-access-from-files ^
  --disk-cache-dir=null ^
  "%URL%"
 
-:: Attente de quelques secondes pour que Chrome ouvre le port
-echo.
-echo Attente de l'initialisation de Chrome...
-timeout /t 15 /nobreak > nul
-netsh interface portproxy add v4tov4 listenport=9222 connectaddress=127.0.0.1 connectport=9222 listenaddress=0.0.0.0
 
-:: Vérifie si le port est bien ouvert
-echo.
-echo Vérification que le port %REMOTE_PORT% est actif...
-netstat -ano | findstr ":%REMOTE_PORT%" > nul
-if errorlevel 1 (
-    echo.
-    echo ERREUR : Chrome n'a pas ouvert le port %REMOTE_PORT%. Debug impossible.
-    echo Vérifiez si un pare-feu ou un antivirus bloque l'ouverture du port.
-    exit /b 3
-)
+REM Desactivation car :
+REM     - l'utilisation du port 9222 peut créer un conflit
+REM     - Il n'est pas prudent d'exposer sur toutes les interfaces
+REM
+:: :: Attente de quelques secondes pour que Chrome ouvre le port
+:: echo.
+:: echo Attente de l'initialisation de Chrome...
+:: timeout /t 15 /nobreak > nul
+:: netsh interface portproxy add v4tov4 listenport=9222 connectaddress=127.0.0.1 connectport=9222 listenaddress=0.0.0.0
+:: 
+:: :: Vérifie si le port est bien ouvert
+:: echo.
+:: echo Vérification que le port %REMOTE_PORT% est actif...
+:: netstat -ano | findstr ":%REMOTE_PORT%" > nul
+:: if errorlevel 1 (
+::     echo.
+::     echo ERREUR : Chrome n'a pas ouvert le port %REMOTE_PORT%. Debug impossible.
+::     echo Vérifiez si un pare-feu ou un antivirus bloque l'ouverture du port.
+::     exit /b 3
+:: )
 
 cls
 echo ============================================


### PR DESCRIPTION
1 - Mise a jour de l'Agent-mt pour :
   - Connexion MQTT de secours (5883 puis 80)
   - Gestion des dossier des logs de la borne
   - Gestion des transmissions des commandes sur MQTT ligne/ligne

2 - Modification du script de lancement de chrome : chrome/chromeKioskRemoteDebugger.bat
     pour gestion du port de remote-debug (127.0.0.1:9222 -> 10.10.x.x:9123)
        - Pour activer le debug à la volée, il faut lancer la commande "debug-on.bat" (via Agent-mt)
        - pour désactiver le debug : "debug-off.bat"
        - Rattrapage prévu du proxy local lors du lancement de chromeKioskRemoteDebugger.bat
    Correction launchSystemWin.sh (modification des saut de lignes :  CRLF -> LF)
